### PR TITLE
Free: Add code fence for GHCI example

### DIFF
--- a/posts/free.md
+++ b/posts/free.md
@@ -251,6 +251,7 @@ type Effect = Coproduct Logging Persist
 
 We are now ready to define and interpret programs mixing logging and persistence:
 
+~~~~~~~~~
 > let prog = store "bar" >> logI "foo" >> store "quux" >> logI "baz" :: Free Effect ()
 > λ> pair const interpretEffect ((return <$> prog) :: Free Effect (IO ()) )
 > "storing bar"
@@ -258,6 +259,7 @@ We are now ready to define and interpret programs mixing logging and persistence
 > "storing quux"
 > "baz"
 > λ> 
+~~~~~~~~~
 
 # Conclusion
 


### PR DESCRIPTION
Hey,

I hope I'm opening this against the right branch. Your blog post about [cofree interpreters](https://abailly.github.io/posts/free.html) doesn't render the last GHCI example properly. Not sure if there's a special highlighter for GHCI.

Thanks for the article. And happy new year! :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/abailly/abailly.github.io/1)
<!-- Reviewable:end -->
